### PR TITLE
[IMP] hr_holidays_leave_repeated: detect dates at limits

### DIFF
--- a/hr_holidays_leave_repeated/models/hr_leave.py
+++ b/hr_holidays_leave_repeated/models/hr_leave.py
@@ -2,6 +2,7 @@
 # Copyright 2024- Le Filament (https://le-filament.com)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
+from datetime import timedelta
 from dateutil.relativedelta import relativedelta
 from pytz import timezone, utc
 
@@ -89,7 +90,7 @@ class HrLeave(models.Model):
         from_dt = fields.Datetime.from_string(leave.date_from)
         to_dt = fields.Datetime.from_string(leave.date_to)
 
-        if (to_dt - from_dt).days > param_dict["days"]:
+        if to_dt - from_dt > timedelta(days=param_dict["days"]):
             raise UserError(param_dict["user_error_msg"])
 
         from_dt, to_dt = self._update_repeated_workday_dates(

--- a/hr_holidays_leave_repeated/tests/test_holidays_leave_repeated.py
+++ b/hr_holidays_leave_repeated/tests/test_holidays_leave_repeated.py
@@ -198,13 +198,13 @@ class TestHolidaysLeaveRepeated(common.TransactionCase):
 
     def test_07_check_dates(self):
         date_start = datetime(2019, 2, 18, 8, 0, 0, 0)
-        date_end = datetime(2019, 2, 20, 18, 0, 0, 0)
+        date_end = datetime(2019, 2, 25, 18, 0, 0, 0)
         with self.assertRaises(UserError):
             self.env["hr.leave"].create(
                 {
                     "holiday_status_id": self.status_1.id,
                     "holiday_type": "employee",
-                    "repeat_every": "workday",
+                    "repeat_every": "week",
                     "repeat_mode": "times",
                     "repeat_limit": 5,
                     "request_date_from": date_start,


### PR DESCRIPTION
When user selects end date that is exactly equal to limit of repeated type, example with start date 2019-02-18 and end date 2019-02-25, the next repeated week leave will overlap with the end date. This is to detect such cases.